### PR TITLE
Fix "Explicitly number replacement fields in a format string" issue

### DIFF
--- a/python/servo/bootstrap_commands.py
+++ b/python/servo/bootstrap_commands.py
@@ -144,7 +144,7 @@ class MachCommands(CommandBase):
         # a directory of the name `rust-std-TRIPLE` inside and then a `lib` directory.
         # This `lib` directory needs to be extracted and merged with the `rustc/lib`
         # directory from the host compiler above.
-        lib_dir = path.join(install_dir, "rustc-nightly-{}".format(host_triple()),
+        lib_dir = path.join(install_dir, "rustc-nightly-{0}".format(host_triple()),
                             "rustc", "lib", "rustlib")
 
         # ensure that the libs for the host's target is downloaded
@@ -156,7 +156,7 @@ class MachCommands(CommandBase):
             target_lib_dir = path.join(lib_dir, target_triple)
             if path.exists(target_lib_dir):
                 # No need to check for force. If --force the directory is already deleted
-                print("Rust lib for target {} already downloaded.".format(target_triple), end=" ")
+                print("Rust lib for target {0} already downloaded.".format(target_triple), end=" ")
                 print("Use |bootstrap-rust --force| to download again.")
                 continue
 
@@ -173,7 +173,7 @@ class MachCommands(CommandBase):
                                       "rustc", "lib", "rustlib", target_triple))
             shutil.rmtree(path.join(install_dir, "rust-std-nightly-%s" % target_triple))
 
-            print("Rust {} libs ready.".format(target_triple))
+            print("Rust {0} libs ready.".format(target_triple))
 
     @Command('bootstrap-rust-docs',
              description='Download the Rust documentation',
@@ -288,7 +288,7 @@ class MachCommands(CommandBase):
         gitversion_output = subprocess.check_output(["git", "--version"])
         gitversion = LooseVersion(gitversion_output.split(" ")[-1])
         if gitversion < LooseVersion("1.8.1"):
-            print("Git version 1.8.1 or above required. Current version is {}"
+            print("Git version 1.8.1 or above required. Current version is {0}"
                   .format(gitversion))
             sys.exit(1)
         submodules = subprocess.check_output(["git", "submodule", "status"])

--- a/python/servo/post_build_commands.py
+++ b/python/servo/post_build_commands.py
@@ -223,7 +223,7 @@ class PostBuildCommands(CommandBase):
             dev_flag = ""
 
         target_dir = os.path.dirname(binary_path)
-        output_apk = "{}.apk".format(binary_path)
+        output_apk = "{0}.apk".format(binary_path)
         try:
             with cd(path.join("support", "android", "build-apk")):
                 subprocess.check_call(["cargo", "run", "--", dev_flag, "-o", output_apk, "-t", target_dir,

--- a/python/servo/testing_commands.py
+++ b/python/servo/testing_commands.py
@@ -460,19 +460,19 @@ class MachCommands(CommandBase):
             width_col4 = max([len(str(x)) for x in result['Difference(%)']])
 
             for p, q, r, s in zip(['Test'], ['First Run'], ['Second Run'], ['Difference(%)']):
-                print ("\033[1m" + "{}|{}|{}|{}".format(p.ljust(width_col1), q.ljust(width_col2), r.ljust(width_col3),
+                print ("\033[1m" + "{0}|{1}|{2}|{3}".format(p.ljust(width_col1), q.ljust(width_col2), r.ljust(width_col3),
                        s.ljust(width_col4)) + "\033[0m" + "\n" + "--------------------------------------------------"
                        + "-------------------------------------------------------------------------")
 
             for a1, b1, c1, d1 in zip(result['Test'], result['Prev_Time'], result['Cur_Time'], result['Difference(%)']):
                 if d1 > 0:
-                    print ("\033[91m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
+                    print ("\033[91m" + "{0}|{1}|{2}|{3}".format(a1.ljust(width_col1),
                            str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
                 elif d1 < 0:
-                    print ("\033[92m" + "{}|{}|{}|{}".format(a1.ljust(width_col1),
+                    print ("\033[92m" + "{0}|{1}|{2}|{3}".format(a1.ljust(width_col1),
                            str(b1).ljust(width_col2), str(c1).ljust(width_col3), str(d1).ljust(width_col4)) + "\033[0m")
                 else:
-                    print ("{}|{}|{}|{}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
+                    print ("{0}|{1}|{2}|{3}".format(a1.ljust(width_col1), str(b1).ljust(width_col2),
                            str(c1).ljust(width_col3), str(d1).ljust(width_col4)))
 
     def jquery_test_runner(self, cmd, release, dev):

--- a/python/tidy.py
+++ b/python/tidy.py
@@ -89,15 +89,15 @@ def check_length(file_name, idx, line):
 def check_whatwg_specific_url(idx, line):
     match = re.search(r"https://html\.spec\.whatwg\.org/multipage/[\w-]+\.html#([\w\:-]+)", line)
     if match is not None:
-        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1))
-        yield (idx + 1, "link to WHATWG may break in the future, use this format instead: {}".format(preferred_link))
+        preferred_link = "https://html.spec.whatwg.org/multipage/#{0}".format(match.group(1))
+        yield (idx + 1, "link to WHATWG may break in the future, use this format instead: {0}".format(preferred_link))
 
 
 def check_whatwg_single_page_url(idx, line):
     match = re.search(r"https://html\.spec\.whatwg\.org/#([\w\:-]+)", line)
     if match is not None:
-        preferred_link = "https://html.spec.whatwg.org/multipage/#{}".format(match.group(1))
-        yield (idx + 1, "links to WHATWG single-page url, change to multi page: {}".format(preferred_link))
+        preferred_link = "https://html.spec.whatwg.org/multipage/#{0}".format(match.group(1))
+        yield (idx + 1, "links to WHATWG single-page url, change to multi page: {0}".format(preferred_link))
 
 
 def check_whitespace(idx, line):
@@ -158,7 +158,7 @@ def check_flake8(file_name, contents):
 
 def check_lock(file_name, contents):
     def find_reverse_dependencies(dependency, version, content):
-        dependency_prefix = "{} {}".format(dependency, version)
+        dependency_prefix = "{0} {1}".format(dependency, version)
         for package in itertools.chain([content["root"]], content["package"]):
             for dependency in package.get("dependencies", []):
                 if dependency.startswith(dependency_prefix):
@@ -185,7 +185,7 @@ def check_lock(file_name, contents):
         for version in versions:
             if version != highest:
                 reverse_dependencies = "\n".join(
-                    "\t\t{}".format(n)
+                    "\t\t{0}".format(n)
                     for n in find_reverse_dependencies(name, version, content)
                 )
                 substitutions = {
@@ -471,7 +471,7 @@ def check_spec(file_name, lines):
     # Pattern representing a line with comment
     comment_patt = re.compile("^\s*///?.+$")
 
-    pattern = "impl {}Methods for {} {{".format(file_name, file_name)
+    pattern = "impl {0}Methods for {1} {{".format(file_name, file_name)
     brace_count = 0
     in_impl = False
     for idx, line in enumerate(lines):
@@ -556,7 +556,7 @@ def scan(faster=False):
 
     error = None
     for error in errors:
-        print "\033[94m{}\033[0m:\033[93m{}\033[0m: \033[91m{}\033[0m".format(*error)
+        print "\033[94m{0}\033[0m:\033[93m{1}\033[0m: \033[91m{2}\033[0m".format(*error)
 
     if error is None:
         print "\033[92mtidy reported no errors.\033[0m"

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/reference/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/html/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/reference/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/reference/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-line-height-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-line-height-tests.py
@@ -62,7 +62,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
     idx += 1
@@ -78,5 +78,5 @@ for (pos, emphasis_pos, ruby_pos, wms, dir) in POSITIONS:
                 pos=pos, wm=wm, tag=tag, index=idx, dir=dir,
                 start=start.format(style1=style1, style2=STYLE2), end=end)
             write_file(test_file, content)
-            print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+            print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-position-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-position-property-tests.py
@@ -50,8 +50,8 @@ def write_test_file(idx, suffix, wm, orient, value, position):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(
         value=value, wm=wm, orient=orient, index=idx, position=position,
-        title=(wm if orient == "mixed" else "{}, {}".format(wm, orient))))
-    reftest_items.append("== {} {}".format(filename, REF_FILE.format(idx)))
+        title=(wm if orient == "mixed" else "{0}, {1}".format(wm, orient))))
+    reftest_items.append("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 def write_test_files(wm, orient, pos1, pos2):
     idx = (REF_MAP_MIXED if orient == "mixed" else REF_MAP_SIDEWAYS)[pos1]
@@ -72,8 +72,8 @@ for wm in WRITING_MODES:
         if wm != "horizontal-tb":
             write_test_files(wm, "sideways", pos1, pos2)
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 reftest_items.sort()
 for item in reftest_items:
     print(item)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-ruby-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-ruby-tests.py
@@ -52,7 +52,7 @@ def write_file(filename, content):
     with open(filename, 'wb') as f:
         f.write(content.encode('UTF-8'))
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 idx = 0
 for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
     idx += 1
@@ -65,5 +65,5 @@ for pos, ref_wm, ruby_pos, subtests in TEST_CASES:
         test_content = TEST_TEMPLATE.format(
             wm=wm, pos=pos, index=idx, ruby_pos=ruby_pos, posval=posval)
         write_file(test_file, test_content)
-        print("== {} {}".format(test_file, ref_file))
-print("# END tests from {}".format(__file__))
+        print("== {0} {1}".format(test_file, ref_file))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-style-property-tests.py
+++ b/tests/wpt/css-tests/css-text-decor-3_dev/xhtml1print/support/generate-text-emphasis-style-property-tests.py
@@ -45,7 +45,7 @@ DATA_SET = [
 SUFFIXES = ['', 'a', 'b', 'c', 'd', 'e']
 
 def get_html_entity(code):
-    return '&#x{:04X};'.format(code)
+    return '&#x{0:04X};'.format(code)
 
 def write_file(filename, content):
     with open(filename, 'wb') as f:
@@ -57,29 +57,29 @@ def write_test_file(idx, suffix, style, code, name=None):
     filename = TEST_FILE.format(idx, suffix)
     write_file(filename, TEST_TEMPLATE.format(index=idx, value=style,
                                               char=get_html_entity(code),
-                                              code='U+{:04X}'.format(code),
+                                              code='U+{0:04X}'.format(code),
                                               title=name))
-    print("== {} {}".format(filename, REF_FILE.format(idx)))
+    print("== {0} {1}".format(filename, REF_FILE.format(idx)))
 
 idx = 10
 def write_files(style, code):
     global idx
     idx += 1
     fill, shape = style
-    basic_style = "{} {}".format(fill, shape)
+    basic_style = "{0} {1}".format(fill, shape)
     write_file(REF_FILE.format(idx),
                REF_TEMPLATE.format(basic_style, get_html_entity(code)))
     suffix = iter(SUFFIXES)
     write_test_file(idx, next(suffix), basic_style, code)
-    write_test_file(idx, next(suffix), "{} {}".format(shape, fill), code)
+    write_test_file(idx, next(suffix), "{0} {1}".format(shape, fill), code)
     if fill == 'filled':
         write_test_file(idx, next(suffix), shape, code)
     if shape == 'circle':
         write_test_file(idx, next(suffix), fill, code, fill + ', horizontal')
 
-print("# START tests from {}".format(__file__))
+print("# START tests from {0}".format(__file__))
 for name, code, _ in DATA_SET:
     write_files(('filled', name), code)
 for name, _, code in DATA_SET:
     write_files(('open', name), code)
-print("# END tests from {}".format(__file__))
+print("# END tests from {0}".format(__file__))

--- a/tests/wpt/web-platform-tests/webgl/tools/import-conformance-tests.py
+++ b/tests/wpt/web-platform-tests/webgl/tools/import-conformance-tests.py
@@ -15,16 +15,16 @@ PATCHES = [
 ]
 
 def usage():
-    print("Usage: {} version destination [existing_webgl_repo]".format(sys.argv[0]))
+    print("Usage: {0} version destination [existing_webgl_repo]".format(sys.argv[0]))
     sys.exit(1)
 
 def get_tests(base_dir, file_name, tests_list):
     list_file = os.path.join(base_dir, file_name)
     if not os.path.isfile(list_file):
-        print("Test list ({}) not found".format(list_file))
+        print("Test list ({0}) not found".format(list_file))
         sys.exit(1)
 
-    print("Processing: {}".format(list_file))
+    print("Processing: {0}".format(list_file))
 
     with open(list_file, "r") as f:
         for line in f:
@@ -54,8 +54,8 @@ def process_test(test):
             if not script_tag_found and "<script" in line:
                 indent = ' ' * line.index('<')
                 script_tag_found = True
-                os.write(new, "{}<script src=/resources/testharness.js></script>\n".format(indent))
-                os.write(new, "{}<script src=/resources/testharnessreport.js></script>\n".format(indent))
+                os.write(new, "{0}<script src=/resources/testharness.js></script>\n".format(indent))
+                os.write(new, "{0}<script src=/resources/testharnessreport.js></script>\n".format(indent))
             os.write(new, line)
 
     os.close(new)
@@ -73,21 +73,21 @@ def main():
     version = args.version
     destination = args.destination
 
-    print("Trying to import WebGL conformance test suite {} into {}".format(version, destination))
+    print("Trying to import WebGL conformance test suite {0} into {1}".format(version, destination))
 
     if args.existing_repo:
         directory = args.existing_repo
-        print("Using existing WebGL repository: {}".format(directory))
+        print("Using existing WebGL repository: {0}".format(directory))
     else:
         directory = tempfile.mkdtemp()
-        print("Cloning WebGL repository into temporary directory {}".format(directory))
+        print("Cloning WebGL repository into temporary directory {0}".format(directory))
         subprocess.check_call(["git", "clone", KHRONOS_REPO_URL, directory])
 
     suite_dir = os.path.join(directory, "conformance-suites", version)
-    print("Test suite directory: {}".format(suite_dir))
+    print("Test suite directory: {0}".format(suite_dir))
 
     if not os.path.isdir(suite_dir):
-        print("Test suite directory ({}) not found, aborting...".format(suite_dir))
+        print("Test suite directory ({0}) not found, aborting...".format(suite_dir))
         sys.exit(1)
 
     # We recursively copy all the test suite to `destination`
@@ -100,7 +100,7 @@ def main():
 
     test_count = len(tests)
 
-    print("Found {} tests.".format(test_count))
+    print("Found {0} tests.".format(test_count))
     print("Removing non-test html files")
 
     # To use binary search, which speeds things up a little
@@ -116,7 +116,7 @@ def main():
             f = os.path.join(dirpath, f)
             pos = bisect.bisect_left(tests, f)
             if pos == test_count or tests[pos] != f:
-                print("Removing: {}".format(f))
+                print("Removing: {0}".format(f))
                 os.remove(f)
 
     # Insert our harness into the tests
@@ -131,8 +131,8 @@ def main():
             patch = os.path.join(this_dir, patch)
             subprocess.check_call(["patch", "-d", destination, file_name, patch])
         except subprocess.CalledProcessError:
-            print("Automatic patch failed for {}".format(file_name))
-            print("Please review the WPT integration and update {} accordingly".format(os.path.basename(patch)))
+            print("Automatic patch failed for {0}".format(file_name))
+            print("Please review the WPT integration and update {0} accordingly".format(os.path.basename(patch)))
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Explicitly number replacement fields in a format string](https://www.quantifiedcode.com/app/issue_class/3aSZNLMu)
Issue details: [https://www.quantifiedcode.com/app/project/gh:rleir:servo?groups=code_patterns/%3A3aSZNLMu](https://www.quantifiedcode.com/app/project/gh:rleir:servo?groups=code_patterns/%3A3aSZNLMu)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
